### PR TITLE
Suppress actual classes warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ google-services.json
 service-credentials.json
 project.xcworkspace
 xcuserdata
+GoogleService-Info.plist

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -70,6 +70,11 @@ kotlin {
 			}
 		}
 	}
+
+	@Suppress("OPT_IN_USAGE")
+	compilerOptions {
+		freeCompilerArgs.add("-Xexpect-actual-classes")
+	}
 }
 
 dependencies {


### PR DESCRIPTION
Fixes 
```
file:///__w/Picover-KMP/Picover-KMP/shared/build/generated/moko/androidMain/src/com/intive/picover/shared/MR.kt:14:8 'expect'/'actual' classes (including interfaces, objects, annotations, enums, and 'actual' typealiases) are in Beta. You can use -Xexpect-actual-classes flag to suppress this warning. Also see: https://youtrack.jetbrains.com/issue/KT-61573